### PR TITLE
Add ESP32 C6 serial bridge package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ https://discuss.ardupilot.org/u/MartinRob/summary
 
 and ClemensElflein
  https://github.com/ClemensElflein/OpenMower
+## ESP32 Serial Bridge
+The `ros/esp32_serial_bridge` package provides a simple interface to an ESP32 C6 over USB serial. Other ROS nodes can publish commands to `mower_control` and receive status on `mower_status`.
+

--- a/ros/esp32_serial_bridge/CMakeLists.txt
+++ b/ros/esp32_serial_bridge/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(esp32_serial_bridge)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS
+  scripts/esp32_serial_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/ros/esp32_serial_bridge/README.md
+++ b/ros/esp32_serial_bridge/README.md
@@ -1,0 +1,9 @@
+# ESP32 Serial Bridge
+
+This package provides a simple ROS node for communicating with an ESP32 C6
+microcontroller over a USB serial connection. Other parts of the OpenMower
+system can publish commands to the `mower_control` topic and receive status
+from the `mower_status` topic.
+
+The actual mower control logic should be implemented on the ESP32. This node
+only forwards string messages between ROS and the serial port.

--- a/ros/esp32_serial_bridge/package.xml
+++ b/ros/esp32_serial_bridge/package.xml
@@ -1,0 +1,11 @@
+<package format="2">
+  <name>esp32_serial_bridge</name>
+  <version>0.1.0</version>
+  <description>Serial bridge for ESP32 C6 mower hardware.</description>
+  <maintainer email="you@example.com">Your Name</maintainer>
+  <license>MIT</license>
+
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>pyserial</exec_depend>
+</package>

--- a/ros/esp32_serial_bridge/scripts/esp32_serial_node.py
+++ b/ros/esp32_serial_bridge/scripts/esp32_serial_node.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import rospy
+import serial
+from std_msgs.msg import String
+
+class ESP32SerialBridge:
+    def __init__(self):
+        port = rospy.get_param('~port', '/dev/ttyUSB0')
+        baud = rospy.get_param('~baud', 115200)
+        try:
+            self.ser = serial.Serial(port, baud, timeout=1)
+        except serial.SerialException as e:
+            rospy.logerr(f"Failed to open serial port {port}: {e}")
+            self.ser = None
+
+        self.cmd_sub = rospy.Subscriber('mower_control', String, self.send_command)
+        self.status_pub = rospy.Publisher('mower_status', String, queue_size=10)
+        rospy.Timer(rospy.Duration(0.1), self.read_serial)
+
+    def send_command(self, msg):
+        if self.ser and self.ser.is_open:
+            try:
+                self.ser.write((msg.data + '\n').encode('utf-8'))
+            except serial.SerialException as e:
+                rospy.logerr(f"Serial write failed: {e}")
+
+    def read_serial(self, event):
+        if self.ser and self.ser.is_open and self.ser.in_waiting:
+            try:
+                line = self.ser.readline().decode('utf-8').strip()
+                if line:
+                    self.status_pub.publish(line)
+            except serial.SerialException as e:
+                rospy.logerr(f"Serial read failed: {e}")
+
+
+def main():
+    rospy.init_node('esp32_serial_bridge')
+    ESP32SerialBridge()
+    rospy.loginfo('ESP32 serial bridge started')
+    rospy.spin()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple ROS package `esp32_serial_bridge` for communication with an ESP32 C6 via USB serial
- provide example Python node and basic package files
- mention the new bridge in the README

## Testing
- `python3 -m py_compile ros/esp32_serial_bridge/scripts/esp32_serial_node.py`

------
https://chatgpt.com/codex/tasks/task_e_6854d7b9653c8322bc3b1af4560e419a