### PR TITLE
Add bus enable control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,29 @@
 # EGO-AutoMower
 
-Openmower adaptation for the Ego Z6 mower based on the work by Martin Rob
-https://discuss.ardupilot.org/u/MartinRob/summary
+Openmower adaptation for the Ego Z6 mower based on the work by MartinRob
+and ClemensElflein.
 
-and ClemensElflein
- https://github.com/ClemensElflein/OpenMower
-## ESP32 Serial Bridge
-The `ros/esp32_serial_bridge` package provides a simple interface to an ESP32 C6 over USB serial. Other ROS nodes can publish commands to `mower_control` and receive status on `mower_status`.
+## ROS Integration
 
+Two ROS packages are provided:
+
+* **esp32_serial_bridge** – communicates with the ESP32‑C6 over USB and
+  publishes/subscribes raw RS485 frames.
+* **z6_mower_bridge** – translates between the `open_mower_ros` topics
+  and the RS485 protocol used by the mower. Unknown message mappings are
+  marked with TODOs.
+
+Use `ros/start_z6.sh` to launch the micro-ROS agent and the bridge node.
+
+## Firmware
+
+The firmware inside `firmware/esp32` runs micro-ROS and only forwards
+complete RS485 frames between ROS and the bus. Translation is performed
+on the host computer by `z6_mower_bridge`.
+
+Additional digital I/O is exposed:
+
+* `/blade_enable` (Bool) - turns the mower blades on or off.
+* `/motion_enable` (Bool) - simulates the operator seat switch to allow motion.
+* `/estop_state` (Bool) - publishes the emergency stop status (true when healthy).
+* `/bus_enable` (Bool) - enables RS485 output and pulls the CC pin low for autonomous control.

--- a/firmware/esp32/src/main.cpp
+++ b/firmware/esp32/src/main.cpp
@@ -3,81 +3,47 @@
 #include <rcl/rcl.h>
 #include <rclc/rclc.h>
 #include <rclc/executor.h>
-#include <geometry_msgs/msg/twist.h>
-#include <std_msgs/msg/string.h>
+#include <std_msgs/msg/u_int8_multi_array.h>
+#include <std_msgs/msg/bool.h>
 
 // RS485 serial port at 460800 baud
-HardwareSerial RS485(1);  // use UART1
+HardwareSerial RS485(1);
 
 // Pin definitions
 const int RS485_TX_PIN = 17;
 const int RS485_RX_PIN = 18;
 const int RS485_DE_PIN = 16;  // Driver enable
 const int CC_PIN = 4;         // Pulls Type-C CC line low
-
-// Wheel distance [m] used for diff drive. Adjust to your mower.
-static const float WHEEL_BASE = 0.60f;  // placeholder
+const int BLADE_PIN = 5;      // Controls blade motors
+const int SEAT_PIN = 6;       // Simulates seat switch
+const int ESTOP_PIN = 7;      // Emergency stop input (NC = healthy)
 
 // micro-ROS objects
 rcl_publisher_t rx_pub;
-rcl_subscription_t cmd_sub;
+rcl_subscription_t tx_sub;
+rcl_subscription_t blade_sub;
+rcl_subscription_t seat_sub;
+rcl_subscription_t bus_enable_sub;
+rcl_publisher_t estop_pub;
+rcl_timer_t estop_timer;
 rclc_executor_t executor;
 rclc_support_t support;
 rcl_allocator_t allocator;
 rcl_node_t node;
 
-// Helper to compute CRC16 (polynomial 0x1021)
-uint16_t crc16_update(uint16_t crc, uint8_t a) {
-  crc ^= ((uint16_t)a << 8);
-  for (int i = 0; i < 8; i++) {
-    if (crc & 0x8000)
-      crc = (crc << 1) ^ 0x1021;
-    else
-      crc <<= 1;
-  }
-  return crc;
-}
-
-void send_message(uint8_t id, const uint8_t* data) {
-  uint8_t frame[14];
-  frame[0] = 0x55;
-  frame[1] = 0xAA;
-  frame[2] = id;
-  frame[3] = 14;  // length
-  memcpy(&frame[4], data, 8);
-  uint16_t crc = 0;
-  for (int i = 0; i < 12; ++i) {
-    crc = crc16_update(crc, frame[i]);
-  }
-  frame[12] = crc >> 8;
-  frame[13] = crc & 0xFF;
-
-  digitalWrite(RS485_DE_PIN, HIGH);  // enable driver
-  RS485.write(frame, 14);
-  RS485.flush();
-  digitalWrite(RS485_DE_PIN, LOW);  // back to receive
-}
-
-void cmd_vel_callback(const void* msg_in) {
-  const geometry_msgs__msg__Twist* msg = (const geometry_msgs__msg__Twist*)msg_in;
-  float left = msg->linear.x - 0.5f * WHEEL_BASE * msg->angular.z;
-  float right = msg->linear.x + 0.5f * WHEEL_BASE * msg->angular.z;
-
-  int16_t left_mm_s = (int16_t)(left * 1000.0f);   // scale to mm/s
-  int16_t right_mm_s = (int16_t)(right * 1000.0f); // scale to mm/s
-
-  uint8_t data[8] = {0};
-  data[0] = left_mm_s >> 8;
-  data[1] = left_mm_s & 0xFF;
-  data[2] = right_mm_s >> 8;
-  data[3] = right_mm_s & 0xFF;
-  // remaining bytes unused
-  send_message(0x10, data);  // 0x10: assumed ID for velocity command
-}
+static bool bus_enabled = false;
 
 void setup() {
   pinMode(CC_PIN, OUTPUT);
-  digitalWrite(CC_PIN, LOW);  // disable sensors by pulling CC low
+  digitalWrite(CC_PIN, HIGH);  // keep sensors enabled until autonomous mode
+
+  pinMode(BLADE_PIN, OUTPUT);
+  digitalWrite(BLADE_PIN, LOW);
+
+  pinMode(SEAT_PIN, OUTPUT);
+  digitalWrite(SEAT_PIN, LOW);
+
+  pinMode(ESTOP_PIN, INPUT_PULLUP);
 
   pinMode(RS485_DE_PIN, OUTPUT);
   digitalWrite(RS485_DE_PIN, LOW);
@@ -91,34 +57,71 @@ void setup() {
   rclc_support_init(&support, 0, NULL, &allocator);
   rclc_node_init_default(&node, "ego_mower_bridge", "", &support);
   rclc_publisher_init_default(&rx_pub, &node,
-                              ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, String),
-                              "ll/rs485_raw");
-  rclc_subscription_init_default(&cmd_sub, &node,
-                                 ROSIDL_GET_MSG_TYPE_SUPPORT(geometry_msgs, msg, Twist),
-                                 "ll/cmd_vel");
+                              ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, UInt8MultiArray),
+                              "rs485_rx");
+  rclc_subscription_init_default(&tx_sub, &node,
+                                 ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, UInt8MultiArray),
+                                 "rs485_tx");
+  rclc_subscription_init_default(&blade_sub, &node,
+                                 ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
+                                 "blade_enable");
+  rclc_subscription_init_default(&seat_sub, &node,
+                                 ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
+                                 "motion_enable");
+  rclc_subscription_init_default(&bus_enable_sub, &node,
+                                 ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
+                                 "bus_enable");
+  rclc_publisher_init_default(&estop_pub, &node,
+                              ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Bool),
+                              "estop_state");
 
-  rclc_executor_init(&executor, &support.context, 1, &allocator);
-  rclc_executor_add_subscription(&executor, &cmd_sub, &geometry_msgs__msg__Twist__create(),
-                                &cmd_vel_callback, ON_NEW_DATA);
+  rclc_executor_init(&executor, &support.context, 5, &allocator);
+  rclc_executor_add_subscription(&executor, &tx_sub, NULL, [](const void* msg){
+      if(!bus_enabled) return;
+      const std_msgs__msg__UInt8MultiArray* m = (const std_msgs__msg__UInt8MultiArray*)msg;
+      digitalWrite(RS485_DE_PIN, HIGH);
+      for(size_t i=0;i<m->data.size;i++) {
+          RS485.write(m->data.data[i]);
+      }
+      RS485.flush();
+      digitalWrite(RS485_DE_PIN, LOW);
+  }, ON_NEW_DATA);
+  rclc_executor_add_subscription(&executor, &blade_sub, NULL, [](const void* msg){
+      const std_msgs__msg__Bool* m = (const std_msgs__msg__Bool*)msg;
+      digitalWrite(BLADE_PIN, m->data ? HIGH : LOW);
+  }, ON_NEW_DATA);
+  rclc_executor_add_subscription(&executor, &seat_sub, NULL, [](const void* msg){
+      const std_msgs__msg__Bool* m = (const std_msgs__msg__Bool*)msg;
+      digitalWrite(SEAT_PIN, m->data ? HIGH : LOW);
+  }, ON_NEW_DATA);
+  rclc_executor_add_subscription(&executor, &bus_enable_sub, NULL, [](const void* msg){
+      const std_msgs__msg__Bool* m = (const std_msgs__msg__Bool*)msg;
+      bus_enabled = m->data;
+      digitalWrite(CC_PIN, bus_enabled ? LOW : HIGH);
+  }, ON_NEW_DATA);
+  rclc_timer_init_default(&estop_timer, &support, RCL_MS_TO_NS(100), [](rcl_timer_t *timer, int64_t last_call){
+      (void)timer; (void)last_call;
+      std_msgs__msg__Bool out_msg;
+      out_msg.data = digitalRead(ESTOP_PIN) == HIGH;
+      rcl_publish(&estop_pub, &out_msg, NULL);
+  });
+  rclc_executor_add_timer(&executor, &estop_timer);
 }
 
 void loop() {
-  if (RS485.available()) {
-    String line;
-    while (RS485.available()) {
-      int b = RS485.read();
-      if (b == '\n') break;
-      if (b >= 0) line += (char)b;
-    }
-    if (line.length() > 0) {
-      std_msgs__msg__String msg;
-      msg.data.data = (char*)line.c_str();
-      msg.data.size = line.length();
-      msg.data.capacity = line.length() + 1;
-      rcl_publish(&rx_pub, &msg, NULL);
+  static uint8_t buffer[14];
+  static size_t index = 0;
+  while (RS485.available()) {
+    buffer[index++] = RS485.read();
+    if(index >= sizeof(buffer)) {
+      std_msgs__msg__UInt8MultiArray out_msg;
+      out_msg.data.data = buffer;
+      out_msg.data.size = index;
+      out_msg.data.capacity = sizeof(buffer);
+      rcl_publish(&rx_pub, &out_msg, NULL);
+      index = 0;
     }
   }
 
   rclc_executor_spin_some(&executor, RCL_MS_TO_NS(10));
 }
-

--- a/ros/start_z6.sh
+++ b/ros/start_z6.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Start micro-ROS agent and Z6 mower translation node
+micro_ros_agent serial --dev ${PORT:-/dev/ttyUSB0} &
+rosrun z6_mower_bridge z6_mower_node.py &
+wait

--- a/ros/z6_mower_bridge/CMakeLists.txt
+++ b/ros/z6_mower_bridge/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(z6_mower_bridge)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+  geometry_msgs
+  std_srvs
+)
+
+catkin_package()
+
+catkin_install_python(PROGRAMS
+  scripts/z6_mower_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/ros/z6_mower_bridge/package.xml
+++ b/ros/z6_mower_bridge/package.xml
@@ -1,0 +1,12 @@
+<package format="2">
+  <name>z6_mower_bridge</name>
+  <version>0.1.0</version>
+  <description>Translation layer between open_mower_ros and Z6 mower RS485 bus.</description>
+  <maintainer email="you@example.com">Your Name</maintainer>
+  <license>MIT</license>
+
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+</package>

--- a/ros/z6_mower_bridge/scripts/z6_mower_node.py
+++ b/ros/z6_mower_bridge/scripts/z6_mower_node.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Z6 mower translation node.
+
+This node translates between open_mower_ros topics/services and the
+binary RS485 protocol used by the Ego Z6 mower. It forwards blade,
+motion and bus enable commands to the ESP32 and publishes the emergency
+stop state. The actual mower protocol is not fully known so many
+translations are left as TODO.
+"""
+import rospy
+from geometry_msgs.msg import Twist
+from std_msgs.msg import UInt8MultiArray, Bool
+from std_srvs.srv import SetBool, SetBoolResponse
+
+RS485_TX_TOPIC = 'rs485_tx'
+RS485_RX_TOPIC = 'rs485_rx'
+
+CMD_VEL_TOPIC = 'll/cmd_vel'
+MOWER_ENABLE_SERVICE = 'll/_service/mow_enabled'
+COLLISION_TOPIC = 'll/collision_detected'
+BLADE_SERVICE = 'll/_service/blade_switch'
+MOTION_SERVICE = 'll/_service/motion_enable'
+BLADE_TOPIC = 'blade_enable'
+MOTION_TOPIC = 'motion_enable'
+ESTOP_TOPIC = 'estop_state'
+BUS_ENABLE_TOPIC = 'bus_enable'
+
+# Message IDs (guessed from forum information)
+MSG_VELOCITY = 0x10
+MSG_MOWER_ENABLE = 0x20
+MSG_COLLISION = 0x30
+
+HEADER = [0x55, 0xAA]
+FRAME_LEN = 14
+
+
+def build_frame(msg_id, payload):
+    """Build RS485 frame with CRC16. Payload must be 8 bytes."""
+    frame = bytearray(HEADER)
+    frame.append(msg_id)
+    frame.append(FRAME_LEN)
+    data = bytearray(8)
+    data[:len(payload)] = payload
+    frame.extend(data)
+    crc = 0
+    for b in frame:
+        crc ^= b << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = (crc << 1) ^ 0x1021
+            else:
+                crc <<= 1
+        crc &= 0xFFFF
+    frame.append((crc >> 8) & 0xFF)
+    frame.append(crc & 0xFF)
+    return frame
+
+
+def twist_to_frame(msg):
+    left = msg.linear.x - 0.3 * msg.angular.z  # wheelbase approx
+    right = msg.linear.x + 0.3 * msg.angular.z
+    left_mm_s = int(left * 1000)
+    right_mm_s = int(right * 1000)
+    payload = bytearray(8)
+    payload[0] = (left_mm_s >> 8) & 0xFF
+    payload[1] = left_mm_s & 0xFF
+    payload[2] = (right_mm_s >> 8) & 0xFF
+    payload[3] = right_mm_s & 0xFF
+    return build_frame(MSG_VELOCITY, payload)
+
+
+def mower_enable_frame(enabled):
+    payload = bytearray(8)
+    payload[0] = 1 if enabled else 0
+    return build_frame(MSG_MOWER_ENABLE, payload)
+
+
+class Z6Bridge:
+    def __init__(self):
+        self.tx_pub = rospy.Publisher(RS485_TX_TOPIC, UInt8MultiArray, queue_size=10)
+        self.rx_sub = rospy.Subscriber(RS485_RX_TOPIC, UInt8MultiArray, self.rx_cb)
+        self.cmd_sub = rospy.Subscriber(CMD_VEL_TOPIC, Twist, self.cmd_cb)
+        self.collision_pub = rospy.Publisher(COLLISION_TOPIC, Bool, queue_size=10)
+        self.srv = rospy.Service(MOWER_ENABLE_SERVICE, SetBool, self.handle_enable)
+        self.blade_srv = rospy.Service(BLADE_SERVICE, SetBool, self.handle_blade)
+        self.motion_srv = rospy.Service(MOTION_SERVICE, SetBool, self.handle_motion)
+        self.blade_pub = rospy.Publisher(BLADE_TOPIC, Bool, queue_size=1)
+        self.motion_pub = rospy.Publisher(MOTION_TOPIC, Bool, queue_size=1)
+        self.bus_pub = rospy.Publisher(BUS_ENABLE_TOPIC, Bool, queue_size=1)
+        self.estop_sub = rospy.Subscriber(ESTOP_TOPIC, Bool, self.estop_cb)
+        self.estop_state = True
+
+    def cmd_cb(self, msg):
+        frame = twist_to_frame(msg)
+        self.publish_frame(frame)
+
+    def handle_enable(self, req):
+        frame = mower_enable_frame(req.data)
+        self.publish_frame(frame)
+        self.bus_pub.publish(Bool(data=req.data))
+        return SetBoolResponse(success=True, message='')
+
+    def handle_blade(self, req):
+        self.blade_pub.publish(Bool(data=req.data))
+        return SetBoolResponse(success=True, message='')
+
+    def handle_motion(self, req):
+        self.motion_pub.publish(Bool(data=req.data))
+        return SetBoolResponse(success=True, message='')
+
+    def estop_cb(self, msg):
+        self.estop_state = msg.data
+
+    def publish_frame(self, frame):
+        arr = UInt8MultiArray(data=list(frame))
+        self.tx_pub.publish(arr)
+
+    def rx_cb(self, msg):
+        if len(msg.data) < 5:
+            return
+        msg_id = msg.data[2]
+        if msg_id == MSG_COLLISION:
+            collision = msg.data[4] != 0
+            self.collision_pub.publish(Bool(data=collision))
+        else:
+            # TODO: handle additional incoming message types
+            pass
+
+
+if __name__ == '__main__':
+    rospy.init_node('z6_mower_bridge')
+    Z6Bridge()
+    rospy.loginfo('Z6 mower bridge started')
+    rospy.spin()


### PR DESCRIPTION
## Summary
- expose `/bus_enable` topic in README for RS485 output control
- gate RS485 writes in firmware and toggle CC pin only when bus is enabled
- publish `bus_enable` from the z6 mower bridge when mower autonomy is toggled

## Testing
- `python3 -m py_compile ros/z6_mower_bridge/scripts/z6_mower_node.py`
- `python3 -m py_compile ros/esp32_serial_bridge/scripts/esp32_serial_node.py`
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e8ebf938832284e2f7f1324c4201